### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/composer-require-checker.yml
+++ b/.github/workflows/composer-require-checker.yml
@@ -24,10 +24,11 @@ on:
 
 name: Composer require checker
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
-  permissions:
-    contents: read
-    pull-requests: write
   composer-require-checker:
     uses: yiisoft/actions/.github/workflows/composer-require-checker.yml@master
     with:


### PR DESCRIPTION
Potential fix for [https://github.com/rossaddison/data-cycle/security/code-scanning/2](https://github.com/rossaddison/data-cycle/security/code-scanning/2)

To fix the issue, an explicit `permissions` block must be set at the workflow root level (before `jobs:`) to enforce least privilege for the GITHUB_TOKEN. This ensures that all jobs in this workflow will inherit these minimal permissions unless individually overridden. The best way is to move the block currently under `jobs:` to above it (i.e., after `name: ...` and before `jobs:`). No changes to job logic or steps are necessary, just a reorganization in the YAML structure for proper enforcement.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
