### PR TITLE
Potential fix for code scanning alert no. 10: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/sqlite.yml
+++ b/.github/workflows/sqlite.yml
@@ -20,6 +20,8 @@ on:
       - 'psalm.xml'
 
 name: sqlite
+permissions:
+  contents: read
 
 jobs:
   phpunit:


### PR DESCRIPTION
Potential fix for [https://github.com/rossaddison/data-cycle/security/code-scanning/10](https://github.com/rossaddison/data-cycle/security/code-scanning/10)

In general, the fix is to explicitly declare a `permissions` block for the workflow or for the `phpunit` job, granting only the least privileges required. For this workflow, the steps perform source checkout, dependency installation, tests, and uploading coverage to Codecov. These actions only require read access to the repository contents; they do not push commits, modify issues, or update pull requests. Therefore, the best fix is to set `permissions: contents: read` at the workflow level, right after the `name: sqlite` line. This will apply to all jobs that do not override permissions and satisfies the CodeQL recommendation.

Concretely, in `.github/workflows/sqlite.yml`, insert:

```yaml
permissions:
  contents: read
```

between the existing `name: sqlite` line and the `jobs:` block. No additional imports or external dependencies are needed, and existing job steps remain unchanged. This will ensure the `GITHUB_TOKEN` is restricted to read-only access to repository contents for this workflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
