### PR TITLE
Potential fix for code scanning alert no. 9: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pgsql.yml
+++ b/.github/workflows/pgsql.yml
@@ -21,6 +21,8 @@ on:
       - 'psalm.xml'
 
 name: pgsql
+permissions:
+  contents: read
 
 jobs:
   tests:


### PR DESCRIPTION
Potential fix for [https://github.com/rossaddison/data-cycle/security/code-scanning/9](https://github.com/rossaddison/data-cycle/security/code-scanning/9)

In general, the fix is to explicitly set a `permissions` block either at the top (workflow-level, applying to all jobs by default) or within the specific job. Here we only have one job (`tests`), so either location works. To avoid changing behavior while still following least-privilege, the best starting point is the recommended minimal permissions `contents: read`, which is sufficient for `actions/checkout`, `actions/cache`, and typical test/coverage workflows that do not write to the repository or manage PRs.

The single best fix here is to add a workflow-level `permissions` block right after the `name: pgsql` line, applying to all jobs. That keeps functionality unchanged (the job will still be able to check out code and run tests) while reducing the `GITHUB_TOKEN` to read-only contents. No additional methods, imports, or external definitions are required because this is just YAML configuration. Only `.github/workflows/pgsql.yml` needs to be edited, and only around the workflow header (after line 23).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
