### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -22,6 +22,9 @@ on:
 
 name: static analysis
 
+permissions:
+  contents: read
+
 jobs:
   psalm:
     uses: yiisoft/actions/.github/workflows/psalm.yml@master


### PR DESCRIPTION
Potential fix for [https://github.com/rossaddison/data-cycle/security/code-scanning/8](https://github.com/rossaddison/data-cycle/security/code-scanning/8)

- In general, to fix this class of issue, add an explicit `permissions:` section either at the top level of the workflow (to affect all jobs) or within the specific job, setting only the scopes required (commonly `contents: read` for read‑only workflows).
- For this workflow, the best minimal fix without changing functionality is to add a top‑level `permissions:` block that grants read‑only access to repository contents. Static analysis via Psalm should only need to read code and metadata; it does not need to modify repository resources, so `contents: read` is appropriate.
- Concretely, modify `.github/workflows/static.yml` by inserting:

  ```yaml
  permissions:
    contents: read
  ```

  between the `name: static analysis` line and the `jobs:` block.
- No additional methods, imports, or definitions are needed; this is purely a YAML workflow configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
