### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/mssql.yml
+++ b/.github/workflows/mssql.yml
@@ -17,6 +17,8 @@ on:
       - 'phpunit.xml.dist'
 
 name: mssql
+permissions:
+  contents: read
 
 jobs:
   tests:


### PR DESCRIPTION
Potential fix for [https://github.com/rossaddison/data-cycle/security/code-scanning/1](https://github.com/rossaddison/data-cycle/security/code-scanning/1)

In general, the fix is to explicitly set a `permissions` block either at the top level of the workflow (to apply to all jobs) or within the specific job. Since this workflow only needs to read the repository contents and upload coverage to Codecov using an explicit secret token (not `GITHUB_TOKEN`), the minimal permission `contents: read` is sufficient. This conforms to CodeQL’s suggested baseline and the principle of least privilege.

The best fix here is to add a workflow‑level `permissions` section just below the `name: mssql` line (around line 19), setting `contents: read`. This will apply to the `tests` job and any future jobs unless they override it. No changes are needed to steps or external actions because `actions/checkout` and `actions/cache` work with a read‑only token for this use case, and Codecov is using `secrets.CODECOV_TOKEN`. No additional imports or methods are required since this is a YAML configuration change only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
