### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -20,6 +20,9 @@ on:
 
 name: mutation test
 
+permissions:
+  contents: read
+
 jobs:
   mutation:
     uses: yiisoft/actions/.github/workflows/roave-infection.yml@master


### PR DESCRIPTION
Potential fix for [https://github.com/rossaddison/data-cycle/security/code-scanning/4](https://github.com/rossaddison/data-cycle/security/code-scanning/4)

In general, the fix is to explicitly declare a `permissions` block in the workflow so that the `GITHUB_TOKEN` only has the minimal access required. Since this workflow’s only job delegates entirely to a reusable workflow that runs tests (mutation testing), it typically needs to read the repository contents and metadata but not to push changes. Therefore, setting `contents: read` at the workflow level is a safe, minimal baseline; if the reusable workflow requires additional scopes (for example, `checks: write` or `pull-requests: write`), those could be added explicitly, but we should not guess extra write scopes from this snippet.

The best way to fix this without changing behavior is to add a top-level `permissions:` block after the `name:` declaration (or before `on:` if you prefer), applying to all jobs that do not override it. We will set `contents: read`, which is sufficient for most CI/test workflows and aligns with GitHub’s recommended minimal starting point. No imports or additional definitions are needed because this is a YAML configuration change only. Concretely, in `.github/workflows/mutation.yml`, add:

```yaml
permissions:
  contents: read
```

at the top workflow level, e.g., between `name: mutation test` and `jobs:`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
