### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/mysql.yml
+++ b/.github/workflows/mysql.yml
@@ -22,6 +22,9 @@ on:
 
 name: mysql
 
+permissions:
+  contents: read
+
 jobs:
   tests:
     name: PHP ${{ matrix.php }}-mysql-${{ matrix.mysql }}


### PR DESCRIPTION
Potential fix for [https://github.com/rossaddison/data-cycle/security/code-scanning/3](https://github.com/rossaddison/data-cycle/security/code-scanning/3)

In general, the problem is fixed by adding a `permissions:` section either at the top level of the workflow (to apply to all jobs) or under the specific job (`jobs.tests`) to explicitly scope down the `GITHUB_TOKEN` privileges. For this workflow, read-only access to repository contents is sufficient, as the steps only check out code, install dependencies, run tests, use cache, and upload coverage to Codecov.

The minimal, non-breaking fix in this file is to add `permissions: contents: read` at the workflow root (after `name: mysql`), which will apply to all jobs that do not define their own `permissions`. This aligns with CodeQL’s recommended minimal starting point (`contents: read`) and matches the actual needs of the workflow. No other code changes, imports, or definitions are needed.

Concretely, in `.github/workflows/mysql.yml`, insert:

```yaml
name: mysql

permissions:
  contents: read

jobs:
  tests:
    ...
```

leaving the rest of the workflow unchanged.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
