### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/composer-require-checker.yml
+++ b/.github/workflows/composer-require-checker.yml
@@ -23,6 +23,8 @@ on:
       - 'psalm.xml'
 
 name: Composer require checker
+permissions:
+  contents: read
 
 jobs:
   composer-require-checker:


### PR DESCRIPTION
Potential fix for [https://github.com/rossaddison/data-cycle/security/code-scanning/2](https://github.com/rossaddison/data-cycle/security/code-scanning/2)

In general, this problem is fixed by explicitly adding a `permissions` block to the workflow (at the root level or per job) to restrict the `GITHUB_TOKEN` to the least privileges required. For read-only CI checks (like composer-require-checker) that do not need to modify repository resources, `contents: read` is typically sufficient; in many cases you can even set `permissions: read-all` or `permissions: {}` (no permissions) if the checks don’t use the token at all.

For this specific workflow, the best minimal change without altering functionality is to add a root-level `permissions` section just after the `name:` field. Composer require checking normally only needs to read the repository to install dependencies and run analysis, and does not need to write to issues, PRs, or the contents API, so we can safely set `contents: read`. This root-level block will apply to the `composer-require-checker` job, since it has no job-specific permissions. No additional methods, imports, or definitions are needed because this is a pure YAML configuration change in `.github/workflows/composer-require-checker.yml`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
