### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/rector.yml
+++ b/.github/workflows/rector.yml
@@ -10,6 +10,8 @@ on:
       - 'psalm.xml'
 
 name: rector
+permissions:
+  contents: read
 
 jobs:
   rector:


### PR DESCRIPTION
Potential fix for [https://github.com/rossaddison/data-cycle/security/code-scanning/5](https://github.com/rossaddison/data-cycle/security/code-scanning/5)

In general, the fix is to explicitly restrict `GITHUB_TOKEN` permissions in the workflow, either at the root (applies to all jobs) or per job. For a reusable workflow call, GitHub respects the caller’s `permissions` for `GITHUB_TOKEN`, so the safest approach is to set a restrictive `permissions` block at the top level of this workflow. Because this job only runs Rector via a reusable workflow and doesn’t need to modify repository state, read-only access to repository contents is typically sufficient.

Concretely, in `.github/workflows/rector.yml`, add a `permissions:` block after the `name: rector` line (or before `on:`; both are valid, but after `name` is clear and conventional). Set `contents: read` as a minimal starting point. This will ensure the `GITHUB_TOKEN` has read-only access to repository contents for this workflow, while still allowing the reusable workflow to check out and analyze code. No imports or additional definitions are required, as this is pure YAML configuration.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
